### PR TITLE
ci: add GitHub Actions workflow for Gradle build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,10 @@ jobs:
 
       - name: Build
         run: ./gradlew build
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/build/reports/tests/'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew build


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build.yml` to run the full Gradle build on every push and PR to `main`
- Sets up Java 25 (Temurin distribution) and Gradle with caching via `gradle/actions/setup-gradle`
- `./gradlew build` covers compilation, JUnit tests, and Spotless formatting check across both modules (`app` and `kumo`)

## Test plan

- [ ] Open PR and verify the workflow appears under the Checks tab
- [ ] Confirm the build passes (compile + tests + Spotless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)