### PR TITLE
fix: show updated temperature setpoint immediately on room page

### DIFF
--- a/app/src/main/java/org/ethelred/temperature4/DefaultRoomService.java
+++ b/app/src/main/java/org/ethelred/temperature4/DefaultRoomService.java
@@ -62,9 +62,9 @@ public class DefaultRoomService implements RoomService {
         var setting = sensorMapping.hasSensor(name) ? settingRepository.findByRoom(name) : null;
         var currentMode = setting == null ? Mode.valueOf(roomStatus.mode()) : setting.mode();
         var currentTemp = setting == null ? roomStatus.sp() : setting.settingFahrenheit();
+        var newTemp = action.apply(currentTemp);
         var updatedSetting = setting;
         if (mode != currentMode || action != TemperatureSettingAction.NONE) {
-            var newTemp = action.apply(currentTemp);
             if (sensorMapping.hasSensor(name)) {
                 LOGGER.info("Setting update: {} {} {}", name, mode, newTemp);
                 updatedSetting = new Setting(name, newTemp, mode);
@@ -76,7 +76,15 @@ public class DefaultRoomService implements RoomService {
                 kumoJsRepository.setTemperature(name, mode.toString(), newTemp);
             }
         }
-        var optimisticStatus = RoomStatusBuilder.from(roomStatus).withMode(mode.toString());
+        var newTempObj = Temperature.fromFahrenheit(newTemp);
+        var optimisticStatus = RoomStatusBuilder.from(roomStatus).with(b -> {
+            b.mode(mode.toString());
+            if (mode == Mode.heat) {
+                b.spHeat(newTempObj);
+            } else if (mode == Mode.cool) {
+                b.spCool(newTempObj);
+            }
+        });
         var sensorResult = sensorMapping.channelForRoom(name, sensorsClient.getSensorResults());
         return Optional.of(combine(name, optimisticStatus, sensorResult, updatedSetting));
     }

--- a/app/src/main/jte/room.jte
+++ b/app/src/main/jte/room.jte
@@ -15,9 +15,11 @@
         <label for="${mode}">${mode}</label>
     @endfor
     <div>
-        <button name="setting" value="minus">-</button>
+        <button type="button" name="setting" value="minus"
+                data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">-</button>
         <span>$unsafe{room.displaySetting()}</span>
-        <button name="setting" value="plus">+</button>
+        <button type="button" name="setting" value="plus"
+                data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">+</button>
     </div>
 </form>
 <div><a href="${req.contextPath()}">Back</a></div>

--- a/app/src/test/java/org/ethelred/temperature4/DefaultRoomServiceTest.java
+++ b/app/src/test/java/org/ethelred/temperature4/DefaultRoomServiceTest.java
@@ -97,4 +97,14 @@ class DefaultRoomServiceTest {
         assertThat(fakeKumo.modeCallArgs).isEmpty();
         assertThat(fakeKumo.tempCallArgs).isEmpty();
     }
+
+    @Test
+    void updateRoom_optimisticResponse_reflectsNewTemp_whenNoSensor() {
+        fakeKumo.addRoom("TestRoom", kumoAt(70, "heat"));
+
+        var result = service.updateRoom("TestRoom", Mode.heat, TemperatureSettingAction.INCREMENT);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().displaySetting()).isEqualTo("72");
+    }
 }


### PR DESCRIPTION
## Summary

- **Frontend:** +/- buttons were plain `type="submit"` inside a form whose `hx-trigger` only listened for radio changes, so clicking them caused a full browser POST with no optimistic update. Fixed by adding `type="button"` and per-button `hx-post`/`hx-target`/`hx-include` attributes so they fire HTMX requests the same way mode changes do.
- **Backend:** `optimisticStatus` in `DefaultRoomService.updateRoom()` was built with only `withMode()`, leaving `spHeat`/`spCool` at their old values. The kumojs call received the correct new temperature, but the response rendered the old setpoint. Fixed by also updating the relevant setpoint (`spHeat` for heat, `spCool` for cool) in the optimistic response.

## Test plan

- [ ] New unit test `updateRoom_optimisticResponse_reflectsNewTemp_whenNoSensor` passes (`./gradlew :app:test`)
- [ ] On a room page, click + or − — the displayed setpoint updates immediately without a full page reload
- [ ] Change mode — still updates immediately as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)