### PR TITLE
feat: add per-browser Fahrenheit/Celsius toggle

### DIFF
--- a/app/src/main/java/org/ethelred/temperature4/DefaultRoomService.java
+++ b/app/src/main/java/org/ethelred/temperature4/DefaultRoomService.java
@@ -136,6 +136,16 @@ public class DefaultRoomService implements RoomService {
         }
 
         @Override
+        public String roomTemp(Temperature.Unit unit) {
+            if (sensorView == null) {
+                return room.roomTemp(unit);
+            }
+            return """
+                    %s <span class="ago">(%s)</span>
+                    """.formatted(sensorView.temperature().display(unit), room.roomTemp(unit));
+        }
+
+        @Override
         public String mode() {
             return room.mode();
         }
@@ -148,6 +158,17 @@ public class DefaultRoomService implements RoomService {
             return """
                     %s <span class="ago">(%s)</span>
                     """.formatted(setting.settingFahrenheit(), room.displaySetting());
+        }
+
+        @Override
+        public String displaySetting(Temperature.Unit unit) {
+            if (setting == null || sensorView == null) {
+                return room.displaySetting(unit);
+            }
+            var settingTemp = Temperature.fromFahrenheit(setting.settingFahrenheit());
+            return """
+                    %s <span class="ago">(%s)</span>
+                    """.formatted(settingTemp.display(unit), room.displaySetting(unit));
         }
     }
 }

--- a/app/src/main/java/org/ethelred/temperature4/RoomView.java
+++ b/app/src/main/java/org/ethelred/temperature4/RoomView.java
@@ -5,9 +5,17 @@ public interface RoomView extends NamedResult<RoomView> {
 
     String roomTemp();
 
+    default String roomTemp(Temperature.Unit unit) {
+        return roomTemp();
+    }
+
     String mode();
 
     String displaySetting();
+
+    default String displaySetting(Temperature.Unit unit) {
+        return displaySetting();
+    }
 
     @Override
     default RoomView get() {

--- a/app/src/main/java/org/ethelred/temperature4/Temperature.java
+++ b/app/src/main/java/org/ethelred/temperature4/Temperature.java
@@ -54,4 +54,8 @@ public record Temperature(double celsius) {
         // hard coded to F for now.
         return String.valueOf(Math.round(fahrenheit()));
     }
+
+    public String display(Unit unit) {
+        return Math.round(temperature(unit)) + "°" + unit.symbol();
+    }
 }

--- a/app/src/main/java/org/ethelred/temperature4/UIController.java
+++ b/app/src/main/java/org/ethelred/temperature4/UIController.java
@@ -48,7 +48,7 @@ public class UIController {
         var roomsAndSensors = roomService.getRoomsAndSensors();
         var sensors = roomsAndSensors.sensors();
         var roomViews = roomsAndSensors.rooms();
-        var req = new UIRequestContext("", "index", contextPath);
+        var req = new UIRequestContext("", "index", contextPath, readUnitPreference(javalinContext));
         return withLayout(htmx, req, templates.index(req, roomViews, weather, sensors), javalinContext);
     }
 
@@ -58,7 +58,7 @@ public class UIController {
 
         var status = roomService.getRoom(room);
         if (status.isPresent()) {
-            var req = new UIRequestContext(room, "room", contextPath);
+            var req = new UIRequestContext(room, "room", contextPath, readUnitPreference(javalinContext));
             return withLayout(
                     htmx, req, templates.room(req, List.of("off", "heat", "cool"), status.get()), javalinContext);
         }
@@ -88,12 +88,34 @@ public class UIController {
         var optimistic = roomService.updateRoom(room, modeE, action);
         if (optimistic.isPresent()) {
             javalinContext.status(HttpStatus.OK);
-            var req = new UIRequestContext(room, "room", contextPath);
+            var req = new UIRequestContext(room, "room", contextPath, readUnitPreference(javalinContext));
             return withLayout(
                     htmx, req, templates.room(req, List.of("off", "heat", "cool"), optimistic.get()), javalinContext);
         }
         javalinContext.redirect(contextPath + "room/" + room, HttpStatus.SEE_OTHER);
         return "";
+    }
+
+    @Post("/preferences/unit")
+    @Produces(MediaType.TEXT_HTML)
+    public String toggleUnit(Context javalinContext) {
+        var current = readUnitPreference(javalinContext);
+        var next = current == Temperature.Unit.FAHRENHEIT ? Temperature.Unit.CELSIUS : Temperature.Unit.FAHRENHEIT;
+        javalinContext.cookie("temperature_unit", next.name());
+        var referer = javalinContext.header("Referer");
+        javalinContext.redirect(referer != null ? referer : contextPath, HttpStatus.SEE_OTHER);
+        return "";
+    }
+
+    private Temperature.Unit readUnitPreference(Context javalinContext) {
+        var cookie = javalinContext.cookie("temperature_unit");
+        if (cookie != null) {
+            try {
+                return Temperature.Unit.valueOf(cookie);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
+        return Temperature.Unit.FAHRENHEIT;
     }
 
     String withLayout(@Nullable Boolean htmx, UIRequestContext req, JteModel content, Context javalinContext) {

--- a/app/src/main/java/org/ethelred/temperature4/UIRequestContext.java
+++ b/app/src/main/java/org/ethelred/temperature4/UIRequestContext.java
@@ -1,4 +1,4 @@
 // (C) Edward Harman 2025
 package org.ethelred.temperature4;
 
-public record UIRequestContext(String title, String rootClass, String contextPath) {}
+public record UIRequestContext(String title, String rootClass, String contextPath, Temperature.Unit temperatureUnit) {}

--- a/app/src/main/java/org/ethelred/temperature4/kumojs/NamedRoomStatus.java
+++ b/app/src/main/java/org/ethelred/temperature4/kumojs/NamedRoomStatus.java
@@ -2,6 +2,7 @@
 package org.ethelred.temperature4.kumojs;
 
 import org.ethelred.temperature4.RoomView;
+import org.ethelred.temperature4.Temperature;
 
 public record NamedRoomStatus(String name, RoomStatus roomStatus) implements RoomView {
     public String mode() {
@@ -12,7 +13,17 @@ public record NamedRoomStatus(String name, RoomStatus roomStatus) implements Roo
         return roomStatus.roomTemp() == null ? "-" : roomStatus.roomTemp().display();
     }
 
+    @Override
+    public String roomTemp(Temperature.Unit unit) {
+        return roomStatus.roomTemp() == null ? "-" : roomStatus.roomTemp().display(unit);
+    }
+
     public String displaySetting() {
         return roomStatus.setting();
+    }
+
+    @Override
+    public String displaySetting(Temperature.Unit unit) {
+        return roomStatus.setting(unit);
     }
 }

--- a/app/src/main/java/org/ethelred/temperature4/kumojs/RoomStatus.java
+++ b/app/src/main/java/org/ethelred/temperature4/kumojs/RoomStatus.java
@@ -22,6 +22,16 @@ public record RoomStatus(
         return "--";
     }
 
+    public String setting(Temperature.Unit unit) {
+        if ("heat".equalsIgnoreCase(mode()) && spHeat != null) {
+            return spHeat.display(unit);
+        }
+        if ("cool".equalsIgnoreCase(mode()) && spCool != null) {
+            return spCool.display(unit);
+        }
+        return "--";
+    }
+
     public int sp() {
         if ("heat".equalsIgnoreCase(mode()) && spHeat != null) {
             return toInt(spHeat);

--- a/app/src/main/java/org/ethelred/temperature4/openweather/DailyTemp.java
+++ b/app/src/main/java/org/ethelred/temperature4/openweather/DailyTemp.java
@@ -11,4 +11,10 @@ public record DailyTemp(Temperature min, Temperature max) {
     <span class="low">%s</span>/<span class="high">%s</span>
     """.formatted(min.display(), max.display());
     }
+
+    public String display(Temperature.Unit unit) {
+        return """
+    <span class="low">%s</span>/<span class="high">%s</span>
+    """.formatted(min.display(unit), max.display(unit));
+    }
 }

--- a/app/src/main/java/org/ethelred/temperature4/openweather/OpenWeatherResult.java
+++ b/app/src/main/java/org/ethelred/temperature4/openweather/OpenWeatherResult.java
@@ -3,6 +3,7 @@ package org.ethelred.temperature4.openweather;
 
 import io.avaje.jsonb.Json;
 import java.util.List;
+import org.ethelred.temperature4.Temperature;
 
 @Json
 public record OpenWeatherResult(Current current, List<Daily> daily) {
@@ -12,6 +13,13 @@ public record OpenWeatherResult(Current current, List<Daily> daily) {
         }
         var first = daily.getFirst();
         return first.temp().display();
+    }
+
+    public String minMax(Temperature.Unit unit) {
+        if (daily.isEmpty()) {
+            return "";
+        }
+        return daily.getFirst().temp().display(unit);
     }
 
     public String summary() {

--- a/app/src/main/jte/index.jte
+++ b/app/src/main/jte/index.jte
@@ -17,7 +17,7 @@
     <tr><th>Room</th><th>Current</th><th>Mode</th><th>Setting</th></tr>
     @for(var result: rooms)
         @if(result.success() && result instanceof RoomView room)
-            <tr><td><a href="${req.contextPath()}room/${room.name()}">${room.name()}</a></td><td>$unsafe{room.roomTemp()}</td><td>${room.mode()}</td><td>$unsafe{room.displaySetting()}</td></tr>
+            <tr><td><a href="${req.contextPath()}room/${room.name()}">${room.name()}</a></td><td>$unsafe{room.roomTemp(req.temperatureUnit())}</td><td>${room.mode()}</td><td>$unsafe{room.displaySetting(req.temperatureUnit())}</td></tr>
         @elseif(result instanceof ErrorNamedResult<RoomView> error)
             <tr><td><a href="${req.contextPath()}room/${result.name()}">${result.name()}</a></td><td colspan="3">${error.message()}</td></tr>
         @endif
@@ -25,8 +25,8 @@
 </table>
 <h2>Weather</h2>
 <table class="weather"><tr>
-    <td>${weather.current().temp().display()}</td>
-    <td>$unsafe{weather.minMax()}</td>
+    <td>${weather.current().temp().display(req.temperatureUnit())}</td>
+    <td>$unsafe{weather.minMax(req.temperatureUnit())}</td>
     <td>${weather.summary()}</td>
     </tr>
 </table>
@@ -34,6 +34,6 @@
 <table>
     <tr><th>#</th><th>Name</th><th>Current</th><th class="ago">Battery</th><th class="ago">Last Reading</th></tr>
     @for(var sensor: sensors)
-        <tr><td>${sensor.channel()}</td><td>${sensor.name()}</td><td>${sensor.temperature().display()}</td><td class="ago">$unsafe{sensor.batteryOk() ? "&#x1FAAB;" : "&#x1F50B;"}</td><td class="ago">${sensor.age(now)}</td></tr>
+        <tr><td>${sensor.channel()}</td><td>${sensor.name()}</td><td>${sensor.temperature().display(req.temperatureUnit())}</td><td class="ago">$unsafe{sensor.batteryOk() ? "&#x1FAAB;" : "&#x1F50B;"}</td><td class="ago">${sensor.age(now)}</td></tr>
     @endfor
 </table>

--- a/app/src/main/jte/layout.jte
+++ b/app/src/main/jte/layout.jte
@@ -9,7 +9,11 @@
     <title>Heat Control${"".equals(req.title()) ? "" : " - " + req.title()}</title>
 </head>
 <body class="${req.rootClass()} App">
-<h1>${"".equals(req.title()) ? "Heat Control" : req.title()}</h1>
+<h1>${"".equals(req.title()) ? "Heat Control" : req.title()}
+    <form method="post" action="${req.contextPath()}preferences/unit" style="display:inline">
+        <button type="submit">°${req.temperatureUnit().symbol()}</button>
+    </form>
+</h1>
 <div id="content">
 ${body}
 </div>

--- a/app/src/main/jte/room.jte
+++ b/app/src/main/jte/room.jte
@@ -6,7 +6,7 @@
 @param List<String> modeOptions
 @param RoomView room
 
-<div id="current">$unsafe{room.roomTemp()}</div>
+<div id="current">$unsafe{room.roomTemp(req.temperatureUnit())}</div>
 <form method="post" data-hx-trigger="change from:.moderadio" data-hx-post="#" data-hx-target="#content">
     @for(var mode: modeOptions)
         <input class="moderadio" type="radio" id="${mode}" name="mode" value="${mode}"
@@ -17,7 +17,7 @@
     <div>
         <button type="button" name="setting" value="minus"
                 data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">-</button>
-        <span>$unsafe{room.displaySetting()}</span>
+        <span>$unsafe{room.displaySetting(req.temperatureUnit())}</span>
         <button type="button" name="setting" value="plus"
                 data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">+</button>
     </div>

--- a/app/src/test/java/org/ethelred/temperature4/TemperatureTest.java
+++ b/app/src/test/java/org/ethelred/temperature4/TemperatureTest.java
@@ -37,4 +37,18 @@ class TemperatureTest {
         var t = new Temperature(21.3);
         assertThat(t.display()).isEqualTo("70");
     }
+
+    @Test
+    void display_unit_fahrenheit() {
+        // 21.3°C = 70.34°F → rounds to 70
+        var t = new Temperature(21.3);
+        assertThat(t.display(Temperature.Unit.FAHRENHEIT)).isEqualTo("70°F");
+    }
+
+    @Test
+    void display_unit_celsius() {
+        // 21.3°C rounds to 21
+        var t = new Temperature(21.3);
+        assertThat(t.display(Temperature.Unit.CELSIUS)).isEqualTo("21°C");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a toggle button in the page header so each browser can switch between °F and °C display
- Preference is stored in a `temperature_unit` cookie (defaults to Fahrenheit if absent)
- All temperature display — room temps, setpoints, sensors, weather current and min/max — respects the chosen unit
- Adds `Temperature.display(Unit)` returning e.g. `22°C` / `72°F`; existing no-arg `display()` unchanged

## Test Plan

- [ ] `./gradlew check` passes
- [ ] Visit index page — temperatures show in °F with a `°F` button in the header
- [ ] Click `°F` button — page reloads, all temperatures show in °C, button now shows `°C`
- [ ] Navigate to a room page — Celsius preference persists
- [ ] Open a second browser — has its own independent preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)