### PR TITLE
feat: publish Docker image to GHCR on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build distribution
+        run: ./gradlew :app:installDist
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/edward3h/temperature4
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker-publish.yml` triggered on push to `main`
- Builds the app via `./gradlew :app:installDist` then builds and pushes the Docker image
- Publishes to `ghcr.io/edward3h/temperature4` with `latest` and short SHA tags
- Uses `GITHUB_TOKEN` for GHCR authentication — no extra secrets required

## Test plan

- [ ] Merge to main and confirm the "Publish Docker image" workflow runs successfully in the Actions tab
- [ ] Verify the image appears at `https://github.com/edward3h/temperature4/pkgs/container/temperature4`
- [ ] Optionally: `docker pull ghcr.io/edward3h/temperature4:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)