### PR TITLE
fix: correct temperature display encoding and simplify unit formatting

### DIFF
--- a/app/src/main/java/org/ethelred/temperature4/Temperature.java
+++ b/app/src/main/java/org/ethelred/temperature4/Temperature.java
@@ -56,6 +56,6 @@ public record Temperature(double celsius) {
     }
 
     public String display(Unit unit) {
-        return Math.round(temperature(unit)) + "°" + unit.symbol();
+        return String.valueOf(Math.round(temperature(unit)));
     }
 }

--- a/app/src/main/java/org/ethelred/temperature4/UIController.java
+++ b/app/src/main/java/org/ethelred/temperature4/UIController.java
@@ -119,7 +119,7 @@ public class UIController {
     }
 
     String withLayout(@Nullable Boolean htmx, UIRequestContext req, JteModel content, Context javalinContext) {
-        javalinContext.contentType(ContentType.TEXT_HTML);
+        javalinContext.contentType("text/html; charset=UTF-8");
         if (htmx != null && htmx) {
             return writable(content);
         } else {

--- a/app/src/main/java/org/ethelred/temperature4/UIController.java
+++ b/app/src/main/java/org/ethelred/temperature4/UIController.java
@@ -11,7 +11,6 @@ import io.avaje.http.api.Header;
 import io.avaje.http.api.MediaType;
 import io.avaje.http.api.Post;
 import io.avaje.http.api.Produces;
-import io.javalin.http.ContentType;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
 import java.util.List;

--- a/app/src/main/jte/layout.jte
+++ b/app/src/main/jte/layout.jte
@@ -3,6 +3,7 @@
 
 <html>
 <head>
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="${req.contextPath()}style.css" />
     <script src="https://unpkg.com/htmx.org@2.0.3" integrity="sha384-0895/pl2MU10Hqc6jd4RvrthNlDiE9U1tWmX7WRESftEDRosgxNsQG/Ze9YMRzHq" crossorigin="anonymous"></script>
@@ -10,7 +11,7 @@
 </head>
 <body class="${req.rootClass()} App">
 <h1>${"".equals(req.title()) ? "Heat Control" : req.title()}
-    <form method="post" action="${req.contextPath()}preferences/unit" style="display:inline">
+    <form method="post" action="${req.contextPath()}preferences/unit">
         <button type="submit">°${req.temperatureUnit().symbol()}</button>
     </form>
 </h1>

--- a/app/src/main/resources/static/style.css
+++ b/app/src/main/resources/static/style.css
@@ -95,6 +95,18 @@ div.numbers,
 h1 {
   margin-block-end: 0.4em;
 }
+h1 form {
+  display: inline;
+}
+h1 button {
+  appearance: none;
+  background: transparent;
+  border: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  padding: 0 0.2em;
+}
 .controls h1 {
   font-size: 1.6em;
 }

--- a/app/src/test/java/org/ethelred/temperature4/TemperatureTest.java
+++ b/app/src/test/java/org/ethelred/temperature4/TemperatureTest.java
@@ -42,13 +42,13 @@ class TemperatureTest {
     void display_unit_fahrenheit() {
         // 21.3°C = 70.34°F → rounds to 70
         var t = new Temperature(21.3);
-        assertThat(t.display(Temperature.Unit.FAHRENHEIT)).isEqualTo("70°F");
+        assertThat(t.display(Temperature.Unit.FAHRENHEIT)).isEqualTo("70");
     }
 
     @Test
     void display_unit_celsius() {
         // 21.3°C rounds to 21
         var t = new Temperature(21.3);
-        assertThat(t.display(Temperature.Unit.CELSIUS)).isEqualTo("21°C");
+        assertThat(t.display(Temperature.Unit.CELSIUS)).isEqualTo("21");
     }
 }


### PR DESCRIPTION
## Summary

- Set `charset=UTF-8` on the `Content-Type` header and add `<meta charset="utf-8">` to the HTML layout so browsers correctly decode UTF-8 degree symbols (fixes `Â°F` rendering)
- Remove unit suffix from individual temperature values — the toggle button in the heading already makes the unit clear
- Style the unit toggle button to blend with the `h1` heading text (strip browser defaults, inherit font/colour)

## Test plan

- [ ] All 37 tests pass (`./gradlew :app:test`)
- [ ] Temperatures display as plain numbers (e.g. `68`) with no `°F` suffix
- [ ] Toggle button correctly shows `°F` / `°C` without encoding artefacts
- [ ] Toggle button visually matches the heading style

🤖 Generated with [Claude Code](https://claude.com/claude-code)