### PR TITLE
Improve room screen layout and mobile button sizing

### DIFF
--- a/app/src/main/jte/room.jte
+++ b/app/src/main/jte/room.jte
@@ -6,21 +6,26 @@
 @param List<String> modeOptions
 @param RoomView room
 
-<div id="current">$unsafe{room.roomTemp(req.temperatureUnit())}</div>
-<form method="post" data-hx-trigger="change from:.moderadio" data-hx-post="#" data-hx-target="#content">
-    @for(var mode: modeOptions)
-        <input class="moderadio" type="radio" id="${mode}" name="mode" value="${mode}"
-                    checked="${mode.equalsIgnoreCase(room.mode())}"
-        />
-        <label for="${mode}">${mode}</label>
-    @endfor
-    <div>
-        <button type="button" name="setting" value="minus"
-                data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">-</button>
-        <span>$unsafe{room.displaySetting(req.temperatureUnit())}</span>
-        <button type="button" name="setting" value="plus"
-                data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">+</button>
-    </div>
-</form>
-<div><a href="${req.contextPath()}">Back</a></div>
+<div class="room">
+    <div id="current" class="current-temp">$unsafe{room.roomTemp(req.temperatureUnit())}</div>
+    <form method="post" data-hx-trigger="change from:.moderadio" data-hx-post="#" data-hx-target="#content">
+        <div class="modes">
+            @for(var mode: modeOptions)
+                !{var selected = mode.equalsIgnoreCase(room.mode());}
+                <input class="moderadio" type="radio" id="${mode}" name="mode" value="${mode}"
+                            checked="${selected}"
+                />
+                <label for="${mode}" class="mode-option${selected ? " selected" : ""}">${mode}</label>
+            @endfor
+        </div>
+        <div class="setting">
+            <button type="button" class="button minus" name="setting" value="minus"
+                    data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">-</button>
+            <span class="setting-value">$unsafe{room.displaySetting(req.temperatureUnit())}</span>
+            <button type="button" class="button plus" name="setting" value="plus"
+                    data-hx-post="#" data-hx-target="#content" data-hx-include="closest form">+</button>
+        </div>
+    </form>
+    <div class="back"><a href="${req.contextPath()}">Back</a></div>
+</div>
 

--- a/app/src/main/resources/static/style.css
+++ b/app/src/main/resources/static/style.css
@@ -48,45 +48,16 @@ tfoot tr,
   color: white;
 }
 
-div.mode {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-}
-div.button,
-.number {
+.button {
   font-weight: bold;
   font-size: 1.2em;
   padding: 0.2em 0.4em;
   margin: 0 0.4em;
-}
-.button {
   border-radius: 1em;
   border: solid medium black;
 }
-.number span {
-  border: solid medium black;
-  padding: 0.3em;
-}
 .disabled .button {
   border-color: grey;
-}
-
-.number span.minus {
-  border-top-left-radius: 1em;
-  border-bottom-left-radius: 1em;
-  border-right: none;
-}
-.number span.plus {
-  border-top-right-radius: 1em;
-  border-bottom-right-radius: 1em;
-  border-left: none;
-}
-div.numbers,
-.controls .container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }
 
 .selected.partial {
@@ -149,6 +120,50 @@ h1 button {
   align-self: end;
 }
 
+.room {
+  max-width: 28em;
+  margin: 0 auto;
+  padding: 1.5em 1em;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75em;
+}
+.current-temp {
+  font-size: 2.75em;
+  font-weight: 500;
+}
+.modes {
+  display: flex;
+  gap: 0.5em;
+}
+.mode-option {
+  flex: 1;
+  padding: 0.7em 0.5em;
+  border: solid medium black;
+  border-radius: 0.6em;
+  font-weight: bold;
+  cursor: pointer;
+}
+.moderadio {
+  display: none;
+}
+.setting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1em;
+}
+.setting .button {
+  font-size: 1.6em;
+  padding: 0.3em 0.7em;
+  min-width: 1.6em;
+}
+.setting-value {
+  font-size: 2em;
+  font-weight: bold;
+  min-width: 3.5em;
+}
+
 footer {
   position: fixed;
   bottom: 0;
@@ -156,6 +171,24 @@ footer {
   right: 0;
   font-style: italic;
   padding: 0.5em;
+}
+
+@media only screen and (max-width: 599px) {
+  /* mobile: bigger touch targets */
+
+  .room {
+    gap: 1.25em;
+  }
+  .setting .button {
+    font-size: 1.8em;
+    padding: 0.5em 0.8em;
+    min-width: 2.75em;
+    min-height: 2.75em;
+  }
+  .mode-option {
+    padding: 1em 0.5em;
+    font-size: 1.15em;
+  }
 }
 
 @media only screen and (min-width: 480px) {
@@ -175,7 +208,8 @@ footer {
     background-color: rgb(32, 54, 54);
     color: rgb(192, 228, 217);
   }
-  .button {
+  .button,
+  .mode-option {
     border-color: rgb(192, 228, 217);
   }
   .weather .high {


### PR DESCRIPTION
## Summary
- Restructure the room screen (`room.jte`) into a centred panel: large temperature display, a styled segmented control for mode selection, and a clearer +/- setting row, replacing what was previously a thin stack of unstyled elements.
- Add layout/sizing CSS (`.room`, `.modes`/`.mode-option`, `.setting`/`.setting-value`, `.current-temp`) so the screen makes better use of available space on larger viewports, plus a mobile breakpoint (`max-width: 599px`) that enlarges the +/- and mode buttons to comfortable touch-target sizes (~79px).
- Remove unused leftover CSS rules (`.number`, `div.numbers`, `div.button`, `.controls`, `.Weather`, etc.) that didn't match any current markup.

## Test plan
- [x] Verified rendered layout at desktop width (~1280px) — content now fills more of the panel with larger, well-spaced controls
- [x] Verified mobile width (~390px) — +/- buttons measure ~79×79px, mode buttons ~114×66px (well above the 44px touch-target guideline)
- [x] Verified dark mode (`prefers-color-scheme: dark`) — borders/colours remain consistent with the new `.mode-option` styling
- [ ] Smoke-test the live HTMX-driven mode/setting updates against a running backend (Kumo service wasn't reachable in the sandbox used for this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)